### PR TITLE
Update to 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grayskull" %}
-{% set version = "2.3.0" %}
+{% set version = "2.6.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 826702c4165731c044d30af49230a761ffc753bda8f6be38be9be642fd367037
+  sha256: 39ec33a74b716c4e3ed876733669866f1b0743a242e16255e772e793598cb2dd
 
 build:
   number: 0
@@ -49,11 +49,11 @@ outputs:
         - pip
         - pkginfo
         - progressbar2 >=3.53.0
-        - rapidfuzz >=1.7.1
+        - rapidfuzz >=3.0.0
         - requests
         - ruamel.yaml >=0.16.10
         - ruamel.yaml.jinja2
-        - semver >=2.13.0,<3.0.0
+        - semver >=3.0.0,<4.0.0
         - setuptools >=30.3.0
         - stdlib-list
         - tomli
@@ -94,7 +94,7 @@ about:
   summary: Project to generate recipes for conda.
   description: |
     Grayskull is an automatic conda recipe generator.
-    The main goal of this project is to generate concise recipes for conda-forge. 
+    The main goal of this project is to generate concise recipes for conda-forge.
     The Grayskull project was created with the intention to eventually replace conda skeleton.
   dev_url: https://github.com/conda/grayskull
   doc_url: https://github.com/conda/grayskull/blob/main/README.md


### PR DESCRIPTION
grayskull 2.6.0

**Destination channel:** {defaults}

### Links

- [PKG-4066](https://anaconda.atlassian.net/browse/PKG-4066) 
- [Upstream repository](https://github.com/conda/grayskull/tree/v2.6.0)
- Depends on:
   - stdlib-list for py312 ([PR](https://github.com/AnacondaRecipes/stdlib-list-feedstock/pull/5))
  
### Explanation of changes:

- Updated `version`, `sha`, and dependencies

[PKG-4066]: https://anaconda.atlassian.net/browse/PKG-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ